### PR TITLE
fix NotADirectoryError and minor change to KNNApplicabilityDomain scaler

### DIFF
--- a/src/mlchemad/_data.py
+++ b/src/mlchemad/_data.py
@@ -102,7 +102,7 @@ class Datasets:
 
 def _read_data(in_memory: bool = False):
     # Obtain path to folder
-    path = os.path.join(__file__, os.pardir)
+    path = os.path.dirname(__file__)
     # Obtain files in the folder
     data_files = [f for f in os.listdir(path) if f.endswith('.json')]
     # Obtain datasets


### PR DESCRIPTION
Changes:

1. Resolves an error I encountered when testing the package:

> NotADirectoryError: [Errno 20] Not a directory: 
    '{mydirectory}/MLChemAD/src/mlchemad/_data.py/..'

2. For the `KNNApplicabilityDomain` set the scaler to None if `scaling = None`, instead of using `FunctionTransformer`.
   This makes it easier to save the object to json with ml2json