### PR TITLE
Ignore first neighbor in calculation knn threshold with alpha value

### DIFF
--- a/src/mlchemad/applicability_domains.py
+++ b/src/mlchemad/applicability_domains.py
@@ -522,8 +522,8 @@ class KNNApplicabilityDomain(ApplicabilityDomain):
         self.X_norm = self.scaler.fit_transform(X) if self.scaler is not None else X
         # Fit the NN
         self.nn.fit(self.X_norm)
-        # Find the distance to the kNN
-        self.kNN_dist = self.nn.kneighbors(self.X_norm, return_distance=True)[0].mean(axis=1)
+        # Find the distance to the kNN neighbors (ignoring the first neighbor, which is the sample itself)
+        self.kNN_dist = self.nn.kneighbors(self.X_norm, return_distance=True, n_neighbors=self.k+1)[0][:, 1:].mean(axis=1)
         kNN_train_distance_sorted_ = np.trim_zeros(np.sort(self.kNN_dist))
         # Find the confidence threshold
         if self.hard_threshold:


### PR DESCRIPTION
In the calculation of the `threshold_`  value from the  `KNNApplicablityDomain`, the mean distance to the nearest neighbors in `X` is used. However, with the current implementation, the sample itself was also used in the calculation, making the distance to the first neighbor always 0.
This results in an indexing error in the calculation of the threshold with the alpha value if k=1 (as all distances will be zero), but I also think this is not the desired behavior if k>1. 
Here I fixed this by calculating the distance to the k+1 nearest neighbors and then ignoring the first column (i.e. the distance to the sample itself).